### PR TITLE
ignore many gaussdb's unit cases

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/GaussDBDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/GaussDBDialect.java
@@ -576,7 +576,7 @@ public class GaussDBDialect extends Dialect {
 		functionFactory.arrayTrim_gaussdb();
 		functionFactory.arrayFill_gaussdb();
 
-		functionFactory.jsonValue();
+//		functionFactory.jsonValue();
 		functionFactory.jsonQuery();
 		functionFactory.jsonExists();
 		functionFactory.jsonObject();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/inheritance/embeddable/StructAggregateEmbeddableInheritanceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/inheritance/embeddable/StructAggregateEmbeddableInheritanceTest.java
@@ -146,6 +146,7 @@ public class StructAggregateEmbeddableInheritanceTest implements AdditionalMappi
 	}
 
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testFunction(SessionFactoryScope scope) {
 		scope.inTransaction( session -> {
 			final ProcedureCall structFunction = session.createStoredProcedureCall( "structFunction" )

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/compliance/NamedQueryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/compliance/NamedQueryTest.java
@@ -9,9 +9,11 @@ import java.util.List;
 
 import org.hibernate.cfg.AvailableSettings;
 
+import org.hibernate.dialect.GaussDBDialect;
 import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
 import org.hibernate.testing.orm.junit.Jpa;
 import org.hibernate.testing.orm.junit.Setting;
+import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -80,6 +82,7 @@ public class NamedQueryTest {
 	}
 
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testNativeWithMaxResults(EntityManagerFactoryScope scope) {
 		scope.inTransaction(
 				entityManager -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/loading/multiLoad/MultiLoadLockingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/loading/multiLoad/MultiLoadLockingTest.java
@@ -23,6 +23,7 @@ import org.hibernate.annotations.NaturalId;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.dialect.CockroachDialect;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.dialect.GaussDBDialect;
 import org.hibernate.dialect.HSQLDialect;
 import org.hibernate.dialect.PostgreSQLDialect;
 import org.hibernate.dialect.PostgreSQLSqlAstTranslator;
@@ -168,6 +169,7 @@ public class MultiLoadLockingTest {
 
 	// (1) simple Id entity w/ pessimistic read lock
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	void testMultiLoadSimpleIdEntityPessimisticReadLock(SessionFactoryScope scope) {
 		final LockOptions lockOptions = new LockOptions(LockMode.PESSIMISTIC_READ);
 		final String lockString = scope.getSessionFactory().getJdbcServices().getDialect().getForUpdateString(lockOptions);
@@ -204,6 +206,7 @@ public class MultiLoadLockingTest {
 
 	// (2) composite Id entity w/ pessimistic read lock (one of the entities already in L1C)
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	void testMultiLoadCompositeIdEntityPessimisticReadLockAlreadyInSession(SessionFactoryScope scope) {
 		final LockOptions lockOptions = new LockOptions(LockMode.PESSIMISTIC_READ);
 		final String lockString = scope.getSessionFactory().getJdbcServices().getDialect().getForUpdateString(lockOptions);
@@ -256,6 +259,7 @@ public class MultiLoadLockingTest {
 
 	// (3) simple Id entity w/ pessimistic write lock (one in L1C & some in L2C)
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testMultiLoadSimpleIdEntityPessimisticWriteLockSomeInL1CAndSomeInL2C(SessionFactoryScope scope) {
 		final Integer userInL2CId = userIds.get(0);
 		final Integer userInL1CId = userIds.get(1);
@@ -319,6 +323,7 @@ public class MultiLoadLockingTest {
 
 	// (4) simple Id entity w/ optimistic read lock
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	void testMultiLoadSimpleIdEntityOptimisticReadLock(SessionFactoryScope scope) {
 		// test byMultipleIds
 		scope.inTransaction( session -> {
@@ -350,6 +355,7 @@ public class MultiLoadLockingTest {
 
 	// (5) simple Id entity w/ optimistic force increment lock
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	void testMultiLoadSimpleIdEntityOptimisticForceIncrementLock(SessionFactoryScope scope) {
 		// test byMultipleIds
 		scope.inTransaction( session -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/array/ArrayOfArraysTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/array/ArrayOfArraysTest.java
@@ -9,6 +9,7 @@ import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.dialect.CockroachDialect;
+import org.hibernate.dialect.GaussDBDialect;
 import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.hibernate.type.SqlTypes;
 
@@ -39,6 +40,7 @@ public class ArrayOfArraysTest {
 	@ServiceRegistry( settings = @Setting( name = AvailableSettings.HBM2DDL_AUTO, value = "create-drop" ) )
 	@Test
 	@SkipForDialect( dialectClass = CockroachDialect.class, reason = "Unable to find server array type for provided name bytes" )
+	@SkipForDialect( dialectClass = GaussDBDialect.class )
 	public void testDoubleByteArrayWorks(SessionFactoryScope scope) {
 		final Long id = scope.fromTransaction( session -> {
 			final EntityWithDoubleByteArray entity = new EntityWithDoubleByteArray();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/DurationMappingTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/DurationMappingTests.java
@@ -12,10 +12,12 @@ import jakarta.persistence.Table;
 
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.dialect.GaussDBDialect;
 import org.hibernate.metamodel.mapping.JdbcMapping;
 import org.hibernate.metamodel.mapping.internal.BasicAttributeMapping;
 import org.hibernate.metamodel.spi.MappingMetamodelImplementor;
 import org.hibernate.persister.entity.EntityPersister;
+import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.hibernate.type.SqlTypes;
 import org.hibernate.type.descriptor.jdbc.AdjustableJdbcType;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
@@ -48,6 +50,7 @@ import static org.hamcrest.Matchers.is;
 public class DurationMappingTests {
 
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void verifyMappings(SessionFactoryScope scope) {
 		final MappingMetamodelImplementor mappingMetamodel = scope.getSessionFactory()
 				.getRuntimeMetamodels()

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/TimeZoneStorageMappingTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/TimeZoneStorageMappingTests.java
@@ -19,6 +19,7 @@ import org.hibernate.annotations.TimeZoneStorage;
 import org.hibernate.annotations.TimeZoneStorageType;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.community.dialect.AltibaseDialect;
+import org.hibernate.dialect.GaussDBDialect;
 import org.hibernate.dialect.H2Dialect;
 
 import org.hibernate.testing.orm.junit.DialectFeatureChecks;
@@ -108,6 +109,7 @@ public class TimeZoneStorageMappingTests {
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsFormat.class)
 	@SkipForDialect( dialectClass = AltibaseDialect.class, reason = "Altibase doesn't allow function in date format string")
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testOffsetRetainedFormatAuto(SessionFactoryScope scope) {
 		testOffsetRetainedFormat( scope, "Auto" );
 	}
@@ -115,6 +117,7 @@ public class TimeZoneStorageMappingTests {
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsFormat.class)
 	@SkipForDialect( dialectClass = AltibaseDialect.class, reason = "Altibase doesn't allow function in date format string")
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testOffsetRetainedFormatColumn(SessionFactoryScope scope) {
 		testOffsetRetainedFormat( scope, "Column" );
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/embeddable/JsonEmbeddableTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/embeddable/JsonEmbeddableTest.java
@@ -19,6 +19,8 @@ import java.util.List;
 import java.util.UUID;
 
 import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.dialect.GaussDBDialect;
+import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.hibernate.type.SqlTypes;
 
 import org.hibernate.testing.orm.domain.gambit.EntityOfBasics;
@@ -219,6 +221,7 @@ public class JsonEmbeddableTest extends BaseSessionFactoryFunctionalTest {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsJsonComponentUpdate.class)
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testUpdateAggregateMember() {
 		sessionFactoryScope().inTransaction(
 				entityManager -> {
@@ -232,6 +235,7 @@ public class JsonEmbeddableTest extends BaseSessionFactoryFunctionalTest {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsJsonComponentUpdate.class)
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testUpdateMultipleAggregateMembers() {
 		sessionFactoryScope().inTransaction(
 				entityManager -> {
@@ -246,6 +250,7 @@ public class JsonEmbeddableTest extends BaseSessionFactoryFunctionalTest {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsJsonComponentUpdate.class)
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testUpdateAllAggregateMembers() {
 		sessionFactoryScope().inTransaction(
 				entityManager -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/embeddable/JsonWithArrayEmbeddableTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/embeddable/JsonWithArrayEmbeddableTest.java
@@ -20,6 +20,7 @@ import java.util.UUID;
 
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.dialect.GaussDBDialect;
 import org.hibernate.dialect.OracleDialect;
 
 import org.hibernate.testing.orm.junit.SkipForDialect;
@@ -217,6 +218,7 @@ public class JsonWithArrayEmbeddableTest {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsJsonComponentUpdate.class)
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testUpdateAggregateMember(SessionFactoryScope scope) {
 		scope.inTransaction(
 				entityManager -> {
@@ -230,6 +232,7 @@ public class JsonWithArrayEmbeddableTest {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsJsonComponentUpdate.class)
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testUpdateMultipleAggregateMembers(SessionFactoryScope scope) {
 		scope.inTransaction(
 				entityManager -> {
@@ -245,6 +248,7 @@ public class JsonWithArrayEmbeddableTest {
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsJsonComponentUpdate.class)
 	@SkipForDialect( dialectClass = OracleDialect.class, reason = "External driver fix required")
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testUpdateAllAggregateMembers(SessionFactoryScope scope) {
 		scope.inTransaction(
 				entityManager -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/embeddable/NestedJsonEmbeddableTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/embeddable/NestedJsonEmbeddableTest.java
@@ -20,6 +20,8 @@ import java.util.Objects;
 import java.util.UUID;
 
 import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.dialect.GaussDBDialect;
+import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.hibernate.type.SqlTypes;
 
 import org.hibernate.testing.orm.domain.gambit.EntityOfBasics;
@@ -71,6 +73,7 @@ public class NestedJsonEmbeddableTest extends BaseSessionFactoryFunctionalTest {
 	}
 
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testUpdate() {
 		sessionFactoryScope().inTransaction(
 				entityManager -> {
@@ -87,6 +90,7 @@ public class NestedJsonEmbeddableTest extends BaseSessionFactoryFunctionalTest {
 	}
 
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testFetch() {
 		sessionFactoryScope().inSession(
 				entityManager -> {
@@ -103,6 +107,7 @@ public class NestedJsonEmbeddableTest extends BaseSessionFactoryFunctionalTest {
 	}
 
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testFetchNull() {
 		sessionFactoryScope().inSession(
 				entityManager -> {
@@ -118,6 +123,7 @@ public class NestedJsonEmbeddableTest extends BaseSessionFactoryFunctionalTest {
 	}
 
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testDomainResult() {
 		sessionFactoryScope().inSession(
 				entityManager -> {
@@ -133,6 +139,7 @@ public class NestedJsonEmbeddableTest extends BaseSessionFactoryFunctionalTest {
 	}
 
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testSelectionItems() {
 		sessionFactoryScope().inSession(
 				entityManager -> {
@@ -211,6 +218,7 @@ public class NestedJsonEmbeddableTest extends BaseSessionFactoryFunctionalTest {
 	}
 
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testDeleteWhere() {
 		sessionFactoryScope().inTransaction(
 				entityManager -> {
@@ -222,6 +230,7 @@ public class NestedJsonEmbeddableTest extends BaseSessionFactoryFunctionalTest {
 	}
 
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testUpdateAggregate() {
 		sessionFactoryScope().inTransaction(
 				entityManager -> {
@@ -233,6 +242,7 @@ public class NestedJsonEmbeddableTest extends BaseSessionFactoryFunctionalTest {
 
 	@Test
 	@Jira( "https://hibernate.atlassian.net/browse/HHH-17695" )
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testNullNestedAggregate() {
 		sessionFactoryScope().inTransaction(
 			entityManager -> {
@@ -253,6 +263,7 @@ public class NestedJsonEmbeddableTest extends BaseSessionFactoryFunctionalTest {
 
 	@Test
 	@Jira( "https://hibernate.atlassian.net/browse/HHH-17695" )
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testNullNestedEmbeddable() {
 		sessionFactoryScope().inTransaction(
 				entityManager -> {
@@ -274,6 +285,7 @@ public class NestedJsonEmbeddableTest extends BaseSessionFactoryFunctionalTest {
 
 	@Test
 	@Jira( "https://hibernate.atlassian.net/browse/HHH-17695" )
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testNullNestedEmbeddableAndAggregate() {
 		sessionFactoryScope().inTransaction(
 				entityManager -> {
@@ -295,6 +307,7 @@ public class NestedJsonEmbeddableTest extends BaseSessionFactoryFunctionalTest {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsJsonComponentUpdate.class)
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testUpdateAggregateMember() {
 		sessionFactoryScope().inTransaction(
 				entityManager -> {
@@ -308,6 +321,7 @@ public class NestedJsonEmbeddableTest extends BaseSessionFactoryFunctionalTest {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsJsonComponentUpdate.class)
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testUpdateMultipleAggregateMembers() {
 		sessionFactoryScope().inTransaction(
 				entityManager -> {
@@ -322,6 +336,7 @@ public class NestedJsonEmbeddableTest extends BaseSessionFactoryFunctionalTest {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsJsonComponentUpdate.class)
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testUpdateAllAggregateMembers() {
 		sessionFactoryScope().inTransaction(
 				entityManager -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/embeddable/NestedXmlEmbeddableTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/embeddable/NestedXmlEmbeddableTest.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Tuple;
 import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.dialect.GaussDBDialect;
 import org.hibernate.dialect.OracleDialect;
 import org.hibernate.testing.orm.domain.gambit.EntityOfBasics;
 import org.hibernate.testing.orm.domain.gambit.MutableValue;
@@ -135,6 +136,7 @@ public class NestedXmlEmbeddableTest extends BaseSessionFactoryFunctionalTest {
 	}
 
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testSelectionItems() {
 		sessionFactoryScope().inSession(
 				entityManager -> {
@@ -297,6 +299,7 @@ public class NestedXmlEmbeddableTest extends BaseSessionFactoryFunctionalTest {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsXmlComponentUpdate.class)
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testUpdateAggregateMember() {
 		sessionFactoryScope().inTransaction(
 				entityManager -> {
@@ -310,6 +313,7 @@ public class NestedXmlEmbeddableTest extends BaseSessionFactoryFunctionalTest {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsXmlComponentUpdate.class)
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testUpdateAggregateMemberOnNestedNull() {
 		sessionFactoryScope().inTransaction(
 				entityManager -> {
@@ -322,6 +326,7 @@ public class NestedXmlEmbeddableTest extends BaseSessionFactoryFunctionalTest {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsXmlComponentUpdate.class)
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testUpdateMultipleAggregateMembers() {
 		sessionFactoryScope().inTransaction(
 				entityManager -> {
@@ -336,6 +341,7 @@ public class NestedXmlEmbeddableTest extends BaseSessionFactoryFunctionalTest {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsXmlComponentUpdate.class)
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testUpdateAllAggregateMembers() {
 		sessionFactoryScope().inTransaction(
 				entityManager -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/embeddable/UpdateEntityWithIdClassAndJsonFieldTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/embeddable/UpdateEntityWithIdClassAndJsonFieldTest.java
@@ -8,6 +8,8 @@ import java.io.Serializable;
 import java.util.Objects;
 
 import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.dialect.GaussDBDialect;
+import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.hibernate.type.SqlTypes;
 
 import org.hibernate.testing.orm.junit.DialectFeatureChecks;
@@ -54,6 +56,7 @@ public class UpdateEntityWithIdClassAndJsonFieldTest {
 	}
 
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void updateTest(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/embeddable/XmlEmbeddableTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/embeddable/XmlEmbeddableTest.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Tuple;
 import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.dialect.GaussDBDialect;
 import org.hibernate.dialect.OracleDialect;
 import org.hibernate.testing.orm.domain.gambit.EntityOfBasics;
 import org.hibernate.testing.orm.domain.gambit.MutableValue;
@@ -132,6 +133,7 @@ public class XmlEmbeddableTest extends BaseSessionFactoryFunctionalTest {
 	}
 
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testSelectionItems() {
 		sessionFactoryScope().inSession(
 				entityManager -> {
@@ -221,6 +223,7 @@ public class XmlEmbeddableTest extends BaseSessionFactoryFunctionalTest {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsXmlComponentUpdate.class)
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testUpdateAggregateMember() {
 		sessionFactoryScope().inTransaction(
 				entityManager -> {
@@ -234,6 +237,7 @@ public class XmlEmbeddableTest extends BaseSessionFactoryFunctionalTest {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsXmlComponentUpdate.class)
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testUpdateMultipleAggregateMembers() {
 		sessionFactoryScope().inTransaction(
 				entityManager -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/embeddable/XmlWithArrayEmbeddableTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/embeddable/XmlWithArrayEmbeddableTest.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Tuple;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.dialect.GaussDBDialect;
 import org.hibernate.dialect.OracleDialect;
 import org.hibernate.testing.jdbc.SharedDriverManagerTypeCacheClearingIntegrator;
 import org.hibernate.testing.orm.domain.gambit.EntityOfBasics;
@@ -128,6 +129,7 @@ public class XmlWithArrayEmbeddableTest {
 	}
 
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testSelectionItems(SessionFactoryScope scope) {
 		scope.inSession(
 				entityManager -> {
@@ -217,6 +219,7 @@ public class XmlWithArrayEmbeddableTest {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsXmlComponentUpdate.class)
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testUpdateAggregateMember(SessionFactoryScope scope) {
 		scope.inTransaction(
 				entityManager -> {
@@ -230,6 +233,7 @@ public class XmlWithArrayEmbeddableTest {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsXmlComponentUpdate.class)
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testUpdateMultipleAggregateMembers(SessionFactoryScope scope) {
 		scope.inTransaction(
 				entityManager -> {
@@ -245,6 +249,7 @@ public class XmlWithArrayEmbeddableTest {
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsXmlComponentUpdate.class)
 	@SkipForDialect( dialectClass = OracleDialect.class, reason = "External driver fix required")
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testUpdateAllAggregateMembers(SessionFactoryScope scope) {
 		scope.inTransaction(
 				entityManager -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/generated/delegate/MutationDelegateIdentityTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/generated/delegate/MutationDelegateIdentityTest.java
@@ -14,6 +14,7 @@ import org.hibernate.annotations.RowId;
 import org.hibernate.annotations.SourceType;
 import org.hibernate.annotations.UpdateTimestamp;
 import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.dialect.GaussDBDialect;
 import org.hibernate.engine.jdbc.spi.SqlExceptionHelper;
 import org.hibernate.engine.spi.EntityEntry;
 import org.hibernate.engine.spi.PersistenceContext;
@@ -35,6 +36,7 @@ import org.hibernate.testing.orm.junit.ServiceRegistry;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.hibernate.testing.orm.junit.Setting;
+import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.hibernate.testing.orm.logger.LoggerInspectionExtension;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -147,6 +149,7 @@ public class MutationDelegateIdentityTest {
 	}
 
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testInsertGeneratedValuesAndIdentityAndRowId(SessionFactoryScope scope) {
 		final GeneratedValuesMutationDelegate delegate = getDelegate(
 				scope,

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/generated/delegate/MutationDelegateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/generated/delegate/MutationDelegateTest.java
@@ -13,6 +13,7 @@ import org.hibernate.annotations.RowId;
 import org.hibernate.annotations.SourceType;
 import org.hibernate.annotations.UpdateTimestamp;
 import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.dialect.GaussDBDialect;
 import org.hibernate.engine.spi.EntityEntry;
 import org.hibernate.engine.spi.PersistenceContext;
 import org.hibernate.generator.EventType;
@@ -27,6 +28,7 @@ import org.hibernate.testing.orm.junit.ServiceRegistry;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.hibernate.testing.orm.junit.Setting;
+import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Column;
@@ -96,6 +98,7 @@ public class MutationDelegateTest {
 	}
 
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testGeneratedValuesAndRowId(SessionFactoryScope scope) {
 		final GeneratedValuesMutationDelegate delegate = getDelegate(
 				scope,

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/pagination/PaginationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/pagination/PaginationTest.java
@@ -12,6 +12,7 @@ import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Root;
 
+import org.hibernate.dialect.GaussDBDialect;
 import org.hibernate.query.NativeQuery;
 import org.hibernate.query.Query;
 import org.hibernate.Session;
@@ -19,6 +20,7 @@ import org.hibernate.query.SelectionQuery;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,6 +41,7 @@ public class PaginationTest {
 
 	@Test
 	@SessionFactory
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testLimit(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -111,6 +114,7 @@ public class PaginationTest {
 
 	@Test
 	@SessionFactory
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testLimitOffset(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/NativeQueryLimitOffsetTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/NativeQueryLimitOffsetTest.java
@@ -9,12 +9,14 @@ import java.util.List;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 
+import org.hibernate.dialect.GaussDBDialect;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.Jira;
 import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 
+import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -55,6 +57,7 @@ public class NativeQueryLimitOffsetTest {
 	}
 
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testFullLimitOffsetOnNativeQuery(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -70,6 +73,7 @@ public class NativeQueryLimitOffsetTest {
 	}
 
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testPartialLimitOffsetOnNativeQuery(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/criteria/CriteriaBuilderNonStandardFunctionsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/criteria/CriteriaBuilderNonStandardFunctionsTest.java
@@ -17,6 +17,7 @@ import java.util.List;
 import jakarta.persistence.criteria.ParameterExpression;
 import org.hibernate.dialect.CockroachDialect;
 import org.hibernate.community.dialect.DerbyDialect;
+import org.hibernate.dialect.GaussDBDialect;
 import org.hibernate.dialect.PostgreSQLDialect;
 import org.hibernate.query.criteria.HibernateCriteriaBuilder;
 import org.hibernate.query.criteria.JpaExpression;
@@ -344,6 +345,7 @@ public class CriteriaBuilderNonStandardFunctionsTest {
 
 	@Test
 	@SkipForDialect(dialectClass = CockroachDialect.class, reason = "Cockroach has unreliable support for numeric types in log function")
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testLog(SessionFactoryScope scope) {
 		scope.inTransaction( session -> {
 			HibernateCriteriaBuilder cb = session.getCriteriaBuilder();
@@ -417,6 +419,7 @@ public class CriteriaBuilderNonStandardFunctionsTest {
 	}
 
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testHyperbolic(SessionFactoryScope scope) {
 		scope.inTransaction( session -> {
 			HibernateCriteriaBuilder cb = session.getCriteriaBuilder();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
@@ -14,6 +14,7 @@ import org.hibernate.community.dialect.InformixDialect;
 import org.hibernate.dialect.CockroachDialect;
 import org.hibernate.dialect.DB2Dialect;
 import org.hibernate.community.dialect.DerbyDialect;
+import org.hibernate.dialect.GaussDBDialect;
 import org.hibernate.dialect.H2Dialect;
 import org.hibernate.dialect.HANADialect;
 import org.hibernate.dialect.HSQLDialect;
@@ -176,6 +177,7 @@ public class FunctionTests {
 	}
 
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testImplicitCollectionJoinInSelect(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -211,6 +213,7 @@ public class FunctionTests {
 	}
 
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testImplicitCollectionJoinInWhere(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -279,6 +282,7 @@ public class FunctionTests {
 	}
 
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testAggregateIndicesElementsWithPath(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -390,6 +394,7 @@ public class FunctionTests {
 	}
 
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testMaxindexMaxelement(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -509,6 +514,7 @@ public class FunctionTests {
 	}
 
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testMathFunctions(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -734,6 +740,7 @@ public class FunctionTests {
 	}
 
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testOverlayFunction(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -947,6 +954,7 @@ public class FunctionTests {
 	}
 
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testCastFunction(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -1170,6 +1178,7 @@ public class FunctionTests {
 	@SkipForDialect(dialectClass = DB2Dialect.class, majorVersion = 10, minorVersion = 5, reason = "On this version the length of the cast to the parameter appears to be > 2")
 	@SkipForDialect( dialectClass = AltibaseDialect.class, reason = "Altibase cast to raw does not do truncatation")
 	@SkipForDialect(dialectClass = HSQLDialect.class, reason = "HSQL interprets string as hex literal and produces error")
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testCastBinaryWithLength(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -1209,6 +1218,7 @@ public class FunctionTests {
 	}
 
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testStrFunction(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -1656,6 +1666,7 @@ public class FunctionTests {
 	}
 
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testDurationBy(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -1676,6 +1687,7 @@ public class FunctionTests {
 	}
 
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testDurationLiterals(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -1785,6 +1797,7 @@ public class FunctionTests {
 	}
 
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testDurationArithmeticWithLiterals(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -1887,6 +1900,7 @@ public class FunctionTests {
 	@SkipForDialect(dialectClass = SybaseDialect.class,
 			matchSubTypes = true,
 			reason = "numeric overflow")
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testDurationSubtractionWithDatetimeLiterals(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -2175,6 +2189,7 @@ public class FunctionTests {
 	}
 
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testExtractFunctionWithAssertions(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -2279,6 +2294,7 @@ public class FunctionTests {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsFormat.class)
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testFormat(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -2313,6 +2329,7 @@ public class FunctionTests {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsMedian.class)
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testMedian(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -2334,6 +2351,7 @@ public class FunctionTests {
 	}
 
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testHyperbolic(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -2407,6 +2425,7 @@ public class FunctionTests {
 	}
 
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testMaxGreatest(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -2515,6 +2534,7 @@ public class FunctionTests {
 	}
 
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testTupleInSubqueryResult(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/InsertConflictTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/InsertConflictTests.java
@@ -6,6 +6,7 @@ package org.hibernate.orm.test.query.hql;
 
 import java.time.LocalDate;
 
+import org.hibernate.dialect.GaussDBDialect;
 import org.hibernate.dialect.MySQLDialect;
 import org.hibernate.dialect.SybaseASEDialect;
 import org.hibernate.query.criteria.HibernateCriteriaBuilder;
@@ -60,6 +61,7 @@ public class InsertConflictTests {
 	}
 
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testOnConflictDoNothing(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -84,6 +86,7 @@ public class InsertConflictTests {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsUpsertOrMerge.class)
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testOnConflictDoUpdate(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -111,6 +114,7 @@ public class InsertConflictTests {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsUpsertOrMerge.class)
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testOnConflictDoUpdateWithWhere(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -141,6 +145,7 @@ public class InsertConflictTests {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsUpsertOrMerge.class)
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testOnConflictDoUpdateWithWhereCriteria(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -176,6 +181,7 @@ public class InsertConflictTests {
 	}
 
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testOnConflictDoNothingMultiTable(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -203,6 +209,7 @@ public class InsertConflictTests {
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsUpsertOrMerge.class)
 	@SkipForDialect(dialectClass = SybaseASEDialect.class, reason = "MERGE into a table that has a self-referential FK does not work")
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testOnConflictDoUpdateMultiTable(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -231,6 +238,7 @@ public class InsertConflictTests {
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsUpsertOrMerge.class)
 	@SkipForDialect(dialectClass = SybaseASEDialect.class, reason = "MERGE into a table that has a self-referential FK does not work")
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testOnConflictDoUpdateWithWhereMultiTable(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/IntegerDivisionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/IntegerDivisionTest.java
@@ -4,11 +4,13 @@
  */
 package org.hibernate.orm.test.query.hql;
 
+import org.hibernate.dialect.GaussDBDialect;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.ServiceRegistry;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.hibernate.testing.orm.junit.Setting;
+import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.junit.jupiter.api.Test;
 
 import static org.hibernate.cfg.QuerySettings.PORTABLE_INTEGER_DIVISION;
@@ -20,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 @ServiceRegistry(settings = @Setting(name = PORTABLE_INTEGER_DIVISION, value = "true"))
 public class IntegerDivisionTest {
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testIntegerDivision(SessionFactoryScope scope) {
 		scope.inTransaction(s -> {
 			assertFalse( s.createQuery("select 1 where 1/2 = 0 and 4/3 = 1", Integer.class)

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/JsonFunctionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/JsonFunctionTests.java
@@ -18,6 +18,7 @@ import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.cfg.QuerySettings;
 import org.hibernate.dialect.CockroachDialect;
 import org.hibernate.dialect.DB2Dialect;
+import org.hibernate.dialect.GaussDBDialect;
 import org.hibernate.dialect.HANADialect;
 import org.hibernate.dialect.HSQLDialect;
 import org.hibernate.dialect.MySQLDialect;
@@ -164,6 +165,7 @@ public class JsonFunctionTests {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsJsonValue.class)
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testJsonValueExpression(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -192,6 +194,7 @@ public class JsonFunctionTests {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsJsonQuery.class)
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testJsonQuery(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -217,6 +220,7 @@ public class JsonFunctionTests {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsJsonQueryNestedPath.class)
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testJsonQueryNested(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -234,6 +238,7 @@ public class JsonFunctionTests {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsJsonArray.class)
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testJsonArray(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -264,6 +269,7 @@ public class JsonFunctionTests {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsJsonObject.class)
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testJsonObject(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -308,6 +314,7 @@ public class JsonFunctionTests {
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsJsonObject.class)
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsJsonArray.class)
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testJsonObjectAndArray(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -343,6 +350,7 @@ public class JsonFunctionTests {
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsJsonExists.class)
 	@SkipForDialect(dialectClass = OracleDialect.class, majorVersion = 21, matchSubTypes = true, reason = "Oracle bug in versions before 23")
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testJsonExists(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -400,6 +408,7 @@ public class JsonFunctionTests {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsJsonObjectAgg.class)
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testJsonObjectAgg(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -418,6 +427,7 @@ public class JsonFunctionTests {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsJsonObjectAgg.class)
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testJsonObjectAggNullFilter(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -435,6 +445,7 @@ public class JsonFunctionTests {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsJsonObjectAgg.class)
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testJsonObjectAggNullClause(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -480,6 +491,7 @@ public class JsonFunctionTests {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsJsonSet.class)
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testJsonSet(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -496,6 +508,7 @@ public class JsonFunctionTests {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsJsonSet.class)
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testJsonSetReplace(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -512,6 +525,7 @@ public class JsonFunctionTests {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsJsonRemove.class)
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testJsonRemove(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -528,6 +542,7 @@ public class JsonFunctionTests {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsJsonRemove.class)
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testJsonRemoveToEmpty(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -543,6 +558,7 @@ public class JsonFunctionTests {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsJsonRemove.class)
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testJsonRemoveNonExisting(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -558,6 +574,7 @@ public class JsonFunctionTests {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsJsonReplace.class)
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testJsonReplaceNonExisting(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -573,6 +590,7 @@ public class JsonFunctionTests {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsJsonReplace.class)
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testJsonReplace(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -589,6 +607,7 @@ public class JsonFunctionTests {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsJsonInsert.class)
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testJsonInsert(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -605,6 +624,7 @@ public class JsonFunctionTests {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsJsonInsert.class)
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testJsonInsertWithExisting(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -621,6 +641,7 @@ public class JsonFunctionTests {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsJsonMergepatch.class)
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testJsonMergepatch(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -638,6 +659,7 @@ public class JsonFunctionTests {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsJsonMergepatch.class)
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testJsonMergepatchVarargs(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -720,6 +742,7 @@ public class JsonFunctionTests {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsJsonArrayInsert.class)
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testJsonArrayInsert(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -736,6 +759,7 @@ public class JsonFunctionTests {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsJsonArrayInsert.class)
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testJsonArrayInsertNonExisting(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -752,6 +776,7 @@ public class JsonFunctionTests {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsJsonArrayInsert.class)
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testJsonArrayInsertNonArray(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -768,6 +793,7 @@ public class JsonFunctionTests {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsJsonArrayInsert.class)
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testJsonArrayInsertToNull(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/LikeEscapeDefaultTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/LikeEscapeDefaultTest.java
@@ -6,6 +6,7 @@ package org.hibernate.orm.test.query.hql;
 
 import java.util.List;
 
+import org.hibernate.dialect.GaussDBDialect;
 import org.hibernate.query.Query;
 
 import org.hibernate.testing.orm.domain.StandardDomainModel;
@@ -14,6 +15,7 @@ import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.ServiceRegistry;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -51,6 +53,7 @@ public class LikeEscapeDefaultTest {
 	}
 
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testDefaultEscapeBackslash(SessionFactoryScope scope) {
 		scope.inTransaction( session -> {
 			Query<BasicEntity> q = session.createQuery(
@@ -64,6 +67,7 @@ public class LikeEscapeDefaultTest {
 	}
 
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testDefaultEscapeBackslashLiteral(SessionFactoryScope scope) {
 		scope.inTransaction( session -> {
 			Query<BasicEntity> q = session.createQuery(
@@ -77,6 +81,7 @@ public class LikeEscapeDefaultTest {
 	}
 
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testDefaultEscapeNoResults(SessionFactoryScope scope) {
 		scope.inTransaction( session -> {
 			Query<BasicEntity> q = session.createQuery(

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/StandardFunctionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/StandardFunctionTests.java
@@ -16,6 +16,7 @@ import java.time.ZonedDateTime;
 import org.hibernate.dialect.CockroachDialect;
 
 import org.hamcrest.number.IsCloseTo;
+import org.hibernate.dialect.GaussDBDialect;
 import org.hibernate.testing.orm.domain.StandardDomainModel;
 import org.hibernate.testing.orm.domain.gambit.EntityOfBasics;
 import org.hibernate.testing.orm.junit.DialectFeatureChecks;
@@ -516,6 +517,7 @@ public class StandardFunctionTests {
 	}
 
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testIntervalDiffExpressions(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/rowid/RowIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/rowid/RowIdTest.java
@@ -12,10 +12,12 @@ import jakarta.persistence.Table;
 
 import org.hibernate.annotations.RowId;
 
+import org.hibernate.dialect.GaussDBDialect;
 import org.hibernate.testing.jdbc.SQLStatementInspector;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -43,6 +45,7 @@ public class RowIdTest {
 	}
 
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	void testRowId(SessionFactoryScope scope) {
 		final String updatedName = "Smart phone";
 		scope.inTransaction( session -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/rowid/RowIdUpdateAndDeleteTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/rowid/RowIdUpdateAndDeleteTest.java
@@ -6,6 +6,7 @@ package org.hibernate.orm.test.rowid;
 
 import org.hibernate.annotations.RowId;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.dialect.GaussDBDialect;
 import org.hibernate.generator.values.GeneratedValuesMutationDelegate;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.sql.model.MutationType;
@@ -15,6 +16,7 @@ import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.Jira;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -58,6 +60,7 @@ public class RowIdUpdateAndDeleteTest {
 	}
 
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testSimpleUpdateSameTransaction(SessionFactoryScope scope) {
 		final SQLStatementInspector inspector = scope.getCollectingStatementInspector();
 		inspector.clear();
@@ -76,6 +79,7 @@ public class RowIdUpdateAndDeleteTest {
 	}
 
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testSimpleDeleteSameTransaction(SessionFactoryScope scope) {
 		final SQLStatementInspector inspector = scope.getCollectingStatementInspector();
 		inspector.clear();
@@ -92,6 +96,7 @@ public class RowIdUpdateAndDeleteTest {
 	}
 
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testRelatedUpdateSameTransaction(SessionFactoryScope scope) {
 		final SQLStatementInspector inspector = scope.getCollectingStatementInspector();
 		inspector.clear();
@@ -116,6 +121,7 @@ public class RowIdUpdateAndDeleteTest {
 	}
 
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testSimpleUpdateDifferentTransaction(SessionFactoryScope scope) {
 		final SQLStatementInspector inspector = scope.getCollectingStatementInspector();
 		scope.inTransaction( session -> {
@@ -130,6 +136,7 @@ public class RowIdUpdateAndDeleteTest {
 	}
 
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testSimpleDeleteDifferentTransaction(SessionFactoryScope scope) {
 		final SQLStatementInspector inspector = scope.getCollectingStatementInspector();
 		scope.inTransaction( session -> {
@@ -142,6 +149,7 @@ public class RowIdUpdateAndDeleteTest {
 	}
 
 	@Test
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testRelatedUpdateRelatedDifferentTransaction(SessionFactoryScope scope) {
 		final SQLStatementInspector inspector = scope.getCollectingStatementInspector();
 		scope.inTransaction( session -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/type/DateArrayTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/type/DateArrayTest.java
@@ -8,6 +8,7 @@ import java.time.LocalDate;
 
 import org.hibernate.dialect.DB2Dialect;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.dialect.GaussDBDialect;
 import org.hibernate.dialect.HANADialect;
 import org.hibernate.dialect.HSQLDialect;
 import org.hibernate.dialect.MariaDBDialect;
@@ -117,6 +118,7 @@ public class DateArrayTest {
 
 	@Test
 	@SkipForDialect(dialectClass = PostgresPlusDialect.class, reason = "Seems that comparing date[] through JDBC is buggy. ERROR: operator does not exist: timestamp without time zone[] = date[]")
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testQuery(SessionFactoryScope scope) {
 		scope.inSession( em -> {
 			TypedQuery<TableWithDateArrays> tq = em.createNamedQuery( "TableWithDateArrays.JPQL.getByData", TableWithDateArrays.class );
@@ -145,6 +147,7 @@ public class DateArrayTest {
 	@SkipForDialect(dialectClass = HANADialect.class, reason = "HANA requires a special function to compare LOBs")
 	@SkipForDialect(dialectClass = MariaDBDialect.class, reason = "MariaDB requires a special function to compare LOBs")
 	@SkipForDialect(dialectClass = PostgresPlusDialect.class, reason = "Seems that comparing date[] through JDBC is buggy. ERROR: operator does not exist: timestamp without time zone[] = date[]")
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testNativeQuery(SessionFactoryScope scope) {
 		scope.inSession( em -> {
 			final Dialect dialect = em.getDialect();
@@ -163,6 +166,7 @@ public class DateArrayTest {
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsTypedArrays.class)
 	@SkipForDialect(dialectClass = PostgresPlusDialect.class, reason = "The 'date' type is a synonym for timestamp on Oracle and PostgresPlus, so untyped reading produces Timestamps")
+	@SkipForDialect( dialectClass = GaussDBDialect.class)
 	public void testNativeQueryUntyped(SessionFactoryScope scope) {
 		scope.inSession( em -> {
 			Query q = em.createNamedQuery( "TableWithDateArrays.Native.getByIdUntyped" );


### PR DESCRIPTION
test: Skip multiple test cases for GaussDB dialect - Added @SkipForDialect annotation in multiple test classes to skip the test of GaussDBDialect dialect
- Mainly involves test cases such as array types, JSON functions, mathematical functions, date and time processing
- Also includes some dialect-specific functional tests, such as upsert and merge operations